### PR TITLE
Fix Beep exception on Android

### DIFF
--- a/www/notification.js
+++ b/www/notification.js
@@ -105,6 +105,7 @@ module.exports = {
      * @param {Integer} count       The number of beeps.
      */
     beep: function(count) {
-        exec(null, null, "Notification", "beep", [count]);
+        var defaultedCount = count || 1;
+        exec(null, null, "Notification", "beep", [ defaultedCount ]);
     }
 };


### PR DESCRIPTION
In iOS, if you call the beep function and don't provide a count, it plays a single beep. On Android, however, it always attempts to load the fix object in the array, which is null if no count is provided, causes an exception to be thrown, and no beep to occur. The simplest fix for this is to simply pass `1` if no count is provide from the web.
