### PR TITLE
[CB-6422] Use cordova/exec/proxy instead of platform dupes

### DIFF
--- a/src/firefoxos/notification.js
+++ b/src/firefoxos/notification.js
@@ -151,4 +151,4 @@ var Notification = {
 
 
 module.exports = Notification;
-require('cordova/firefoxos/commandProxy').add('Notification', Notification);
+require('cordova/exec/proxy').add('Notification', Notification);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6422
[CB-6422] Use cordova/exec/proxy instead of platform dupes
