### PR TITLE
Fix for AlertDialog.Builder on API lower than 11

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -151,7 +151,15 @@ public class Notification extends CordovaPlugin {
         Runnable runnable = new Runnable() {
             public void run() {
 
-                AlertDialog.Builder dlg = new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+                AlertDialog.Builder dlg;
+
+                try {
+                    dlg = new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+                }
+                catch(NoSuchMethodError e) {
+                    dlg =  new AlertDialog.Builder(cordova.getActivity());
+                }
+
                 dlg.setMessage(message);
                 dlg.setTitle(title);
                 dlg.setCancelable(true);


### PR DESCRIPTION
When the API is lower than 11, Android throws an NoSuchMethodError because of the second parameter.
This pull request fixes it.