### PR TITLE
CB-7538 Android beep thread fix

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -118,24 +118,28 @@ public class Notification extends CordovaPlugin {
      *
      * @param count     Number of times to play notification
      */
-    public void beep(long count) {
-        Uri ringtone = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-        Ringtone notification = RingtoneManager.getRingtone(this.cordova.getActivity().getBaseContext(), ringtone);
+    public void beep(final long count) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                Uri ringtone = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+                Ringtone notification = RingtoneManager.getRingtone(cordova.getActivity().getBaseContext(), ringtone);
 
-        // If phone is not set to silent mode
-        if (notification != null) {
-            for (long i = 0; i < count; ++i) {
-                notification.play();
-                long timeout = 5000;
-                while (notification.isPlaying() && (timeout > 0)) {
-                    timeout = timeout - 100;
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {
+                // If phone is not set to silent mode
+                if (notification != null) {
+                    for (long i = 0; i < count; ++i) {
+                        notification.play();
+                        long timeout = 5000;
+                        while (notification.isPlaying() && (timeout > 0)) {
+                            timeout = timeout - 100;
+                            try {
+                                Thread.sleep(100);
+                            } catch (InterruptedException e) {
+                            }
+                        }
                     }
                 }
             }
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
Beep now executes in it's own thread.  It was previously executing in the main UI thread which was causing the application to lock up will the beep was occurring.
