### PR TITLE
Check for setTextDirection API level

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -28,6 +28,7 @@ import org.json.JSONObject;
 
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
+import android.app.AlertDialog.Builder;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.media.Ringtone;
@@ -178,10 +179,7 @@ public class Notification extends CordovaPlugin {
                     }
                 });
 
-                dlg.create();
-                AlertDialog dialog =  dlg.show();
-                TextView messageview = (TextView)dialog.findViewById(android.R.id.message);
-                messageview.setTextDirection(android.view.View.TEXT_DIRECTION_LOCALE);
+                changeTextDirection(dlg);
             };
         };
         this.cordova.getActivity().runOnUiThread(runnable);
@@ -253,10 +251,7 @@ public class Notification extends CordovaPlugin {
                     }
                 });
 
-                dlg.create();
-                AlertDialog dialog =  dlg.show();
-                TextView messageview = (TextView)dialog.findViewById(android.R.id.message);
-                messageview.setTextDirection(android.view.View.TEXT_DIRECTION_LOCALE);
+                changeTextDirection(dlg);
             };
         };
         this.cordova.getActivity().runOnUiThread(runnable);
@@ -352,10 +347,7 @@ public class Notification extends CordovaPlugin {
                     }
                 });
 
-                dlg.create();
-                AlertDialog dialog =  dlg.show();
-                TextView messageview = (TextView)dialog.findViewById(android.R.id.message);
-                messageview.setTextDirection(android.view.View.TEXT_DIRECTION_LOCALE);
+                changeTextDirection(dlg);
             };
         };
         this.cordova.getActivity().runOnUiThread(runnable);
@@ -475,6 +467,17 @@ public class Notification extends CordovaPlugin {
             return new ProgressDialog(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
         } else {
             return new ProgressDialog(cordova.getActivity());
+        }
+    }
+    
+    @SuppressLint("NewApi")
+    private void changeTextDirection(Builder dlg){
+        int currentapiVersion = android.os.Build.VERSION.SDK_INT;
+        dlg.create();
+        AlertDialog dialog =  dlg.show();
+        if (currentapiVersion >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            TextView messageview = (TextView)dialog.findViewById(android.R.id.message);
+            messageview.setTextDirection(android.view.View.TEXT_DIRECTION_LOCALE);
         }
     }
 }


### PR DESCRIPTION
Only try to change the textdirection if we are on API >= 17. Before, the dialog would still appear - this just removes a java.lang.NoSuchMethodError.
