### PR TITLE
Fix CB-7734. Changed plugin to use UIAlertController on iOS 8

### DIFF
--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -48,7 +48,20 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
         
         if ([[[UIDevice currentDevice] systemVersion] floatValue] < 8.3) {
-            alertController.view.frame = [[UIScreen mainScreen] applicationFrame];
+            
+            CGFloat screenHeight;
+            CGFloat screenWidth;
+            if ([[UIApplication sharedApplication] statusBarOrientation] == UIDeviceOrientationPortrait || [[UIApplication sharedApplication] statusBarOrientation] == UIDeviceOrientationPortraitUpsideDown){
+                screenHeight = [UIScreen mainScreen].applicationFrame.size.height;
+                screenWidth = [UIScreen mainScreen].applicationFrame.size.width;
+            }
+            else{
+                screenHeight = [UIScreen mainScreen].applicationFrame.size.width;
+                screenWidth = [UIScreen mainScreen].applicationFrame.size.height;
+            }
+            CGRect alertFrame = CGRectMake([UIScreen mainScreen].applicationFrame.origin.x, [UIScreen mainScreen].applicationFrame.origin.y, screenWidth, screenHeight);
+            alertController.view.frame = alertFrame;
+            
         }
         
         for (int n = 0; n < count; n++) {

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -40,28 +40,80 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
  */
 - (void)showDialogWithMessage:(NSString*)message title:(NSString*)title buttons:(NSArray*)buttons defaultText:(NSString*)defaultText callbackId:(NSString*)callbackId dialogType:(NSString*)dialogType
 {
-    CDVAlertView* alertView = [[CDVAlertView alloc]
-        initWithTitle:title
-                  message:message
-                 delegate:self
-        cancelButtonTitle:nil
-        otherButtonTitles:nil];
-
-    alertView.callbackId = callbackId;
-
+    
     NSUInteger count = [buttons count];
-
-    for (int n = 0; n < count; n++) {
-        [alertView addButtonWithTitle:[buttons objectAtIndex:n]];
+    
+    if ([UIAlertController class]) {
+        
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+        
+        alertController.view.frame = [[UIScreen mainScreen] applicationFrame];
+        
+        for (int n = 0; n < count; n++) {
+            
+            UIAlertAction* action = [UIAlertAction actionWithTitle:[buttons objectAtIndex:n] style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                                     {
+                                         CDVPluginResult* result;
+                                         
+                                         if ([dialogType isEqualToString:DIALOG_TYPE_PROMPT]) {
+                                             
+                                             NSString* value0 = [[alertController.textFields objectAtIndex:0] text];
+                                             NSDictionary* info = @{
+                                                                    @"buttonIndex":@(n + 1),
+                                                                    @"input1":(value0 ? value0 : [NSNull null])
+                                                                    };
+                                             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:info];
+                                             
+                                         } else {
+                                             
+                                             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)(n  + 1)];
+                                             
+                                         }
+                                         
+                                         [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+                                         
+                                     }];
+            
+            [alertController addAction:action];
+            
+        }
+        
+        if ([dialogType isEqualToString:DIALOG_TYPE_PROMPT]) {
+            
+            [alertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+                textField.text = defaultText;
+            }];
+        }
+        
+        [self.viewController presentViewController:alertController animated:YES completion:nil];
+        
+    } else {
+        
+        CDVAlertView* alertView = [[CDVAlertView alloc]
+                                   initWithTitle:title
+                                   message:message
+                                   delegate:self
+                                   cancelButtonTitle:nil
+                                   otherButtonTitles:nil];
+        
+        alertView.callbackId = callbackId;
+        
+        
+        
+        for (int n = 0; n < count; n++) {
+            [alertView addButtonWithTitle:[buttons objectAtIndex:n]];
+        }
+        
+        if ([dialogType isEqualToString:DIALOG_TYPE_PROMPT]) {
+            alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
+            UITextField* textField = [alertView textFieldAtIndex:0];
+            textField.text = defaultText;
+        }
+        
+        [alertView show];
+        
     }
-
-    if ([dialogType isEqualToString:DIALOG_TYPE_PROMPT]) {
-        alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
-        UITextField* textField = [alertView textFieldAtIndex:0];
-        textField.text = defaultText;
-    }
-
-    [alertView show];
+    
 }
 
 - (void)alert:(CDVInvokedUrlCommand*)command

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -47,7 +47,9 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
         
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
         
-        alertController.view.frame = [[UIScreen mainScreen] applicationFrame];
+        if ([[[UIDevice currentDevice] systemVersion] floatValue] < 8.3) {
+            alertController.view.frame = [[UIScreen mainScreen] applicationFrame];
+        }
         
         for (int n = 0; n < count; n++) {
             

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -49,19 +49,16 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
         
         if ([[[UIDevice currentDevice] systemVersion] floatValue] < 8.3) {
             
-            CGFloat screenHeight;
-            CGFloat screenWidth;
-            if ([[UIApplication sharedApplication] statusBarOrientation] == UIDeviceOrientationPortrait || [[UIApplication sharedApplication] statusBarOrientation] == UIDeviceOrientationPortraitUpsideDown){
-                screenHeight = [UIScreen mainScreen].applicationFrame.size.height;
-                screenWidth = [UIScreen mainScreen].applicationFrame.size.width;
-            }
-            else{
-                screenHeight = [UIScreen mainScreen].applicationFrame.size.width;
-                screenWidth = [UIScreen mainScreen].applicationFrame.size.height;
-            }
-            CGRect alertFrame = CGRectMake([UIScreen mainScreen].applicationFrame.origin.x, [UIScreen mainScreen].applicationFrame.origin.y, screenWidth, screenHeight);
-            alertController.view.frame = alertFrame;
+            CGRect alertFrame = [UIScreen mainScreen].applicationFrame;
             
+            if (UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
+                // swap the values for the app frame since it is now in landscape
+                CGFloat temp = alertFrame.size.width;
+                alertFrame.size.width = alertFrame.size.height;
+                alertFrame.size.height = temp;
+            }
+            
+            alertController.view.frame =  alertFrame;
         }
         
         for (int n = 0; n < count; n++) {

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -42,8 +42,8 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
 {
     
     NSUInteger count = [buttons count];
-    
-    if ([UIAlertController class]) {
+#ifdef __IPHONE_8_0
+    if (NSClassFromString(@"UIAlertController")) {
         
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
         
@@ -73,7 +73,6 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
                                          [self.commandDelegate sendPluginResult:result callbackId:callbackId];
                                          
                                      }];
-            
             [alertController addAction:action];
             
         }
@@ -85,10 +84,12 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
             }];
         }
         
+        
+        
         [self.viewController presentViewController:alertController animated:YES completion:nil];
         
     } else {
-        
+#endif
         CDVAlertView* alertView = [[CDVAlertView alloc]
                                    initWithTitle:title
                                    message:message
@@ -111,8 +112,9 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
         }
         
         [alertView show];
-        
+#ifdef __IPHONE_8_0
     }
+#endif
     
 }
 


### PR DESCRIPTION
Changed plugin to use UIAlertController on iOS 8 and greater instead of
the UIAlertView as UIAlertView is deprecated now.

It makes the message scrollable if the text is too long (CB-7734)