### PR TITLE
CB-8038 backslash getting escaped twice in bb10

### DIFF
--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -26,7 +26,7 @@ function showDialog(args, dialogType, result) {
     }
 
     if (msg && typeof msg === "string") {
-        msg = msg.replace(/^"|"$/g, "").replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+        msg = msg.replace(/^"|"$/g, "").replace(/\\"/g, '"');
     } else {
         result.error("message is undefined");
         return;


### PR DESCRIPTION
Removed unnecessary escaping of backslash char in notifications for bb10,
as they are already escaped in the js.
