### PR TITLE
Breaking on Windows Phone 8

### DIFF
--- a/src/wp/Notification.cs
+++ b/src/wp/Notification.cs
@@ -183,7 +183,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                             button.Content = buttonLabels[i];
                             button.Tag = i + 1;
                             button.Click += promptBoxbutton_Click;
-                            notifyBox.ButtonPanel.Orientation = Orientation.Vertical;
+                            notifyBox.ButtonPanel.Orientation = System.Windows.Controls.Orientation.Vertical;
                             notifyBox.ButtonPanel.Children.Add(button);
                         }
 


### PR DESCRIPTION
The curren version in the original (master) repository breaks the build due to conflicting namaspace resolution;
Class "Orientation" is present in both "System.Windows.Controls" and "WPCordovaClassLib.Cordova.Commands".
Proposed resolution: Use full namespace notation "System.Windows.Controls.Orientation.Vertical"
