### PR TITLE
CB-9347 - fix to allow to stack multiple UIAlertControllers

### DIFF
--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -98,19 +98,10 @@ static NSMutableArray *alertList = nil;
         if(!alertList)
             alertList = [[NSMutableArray alloc] init];
         [alertList addObject:alertController];
-        dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * ([alertList count]-1)/2);
         
-        dispatch_after(delay, dispatch_get_main_queue(), ^(void){
-            
-            UIViewController *presentingViewController = self.viewController;
-            while(presentingViewController.presentedViewController != nil)
-            {
-                presentingViewController = presentingViewController.presentedViewController;
-            }
-            [presentingViewController presentViewController:alertController animated:YES completion:^{
-                [alertList removeObject:alertController];
-            }];
-        });
+        if ([alertList count]==1) {
+            [self presentAlertcontroller];
+        }
         
     } else {
 #endif
@@ -225,6 +216,25 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
     playBeep([count intValue]);
 }
 
+-(UIViewController *)getTopPresentedViewController {
+    UIViewController *presentingViewController = self.viewController;
+    while(presentingViewController.presentedViewController != nil)
+    {
+        presentingViewController = presentingViewController.presentedViewController;
+    }
+    return presentingViewController;
+}
+
+-(void)presentAlertcontroller {
+    
+    [self.getTopPresentedViewController presentViewController:[alertList firstObject] animated:YES completion:^{
+        [alertList removeObject:[alertList firstObject]];
+        if ([alertList count]>0) {
+            [self presentAlertcontroller];
+        }
+    }];
+    
+}
 
 @end
 

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -23,6 +23,7 @@
 #define DIALOG_TYPE_PROMPT @"prompt"
 
 static void soundCompletionCallback(SystemSoundID ssid, void* data);
+static NSMutableArray *alertList = nil;
 
 @implementation CDVNotification
 
@@ -94,9 +95,22 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
             }];
         }
         
+        if(!alertList)
+            alertList = [[NSMutableArray alloc] init];
+        [alertList addObject:alertController];
+        dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * ([alertList count]-1)/2);
         
-        
-        [self.viewController presentViewController:alertController animated:YES completion:nil];
+        dispatch_after(delay, dispatch_get_main_queue(), ^(void){
+            
+            UIViewController *presentingViewController = self.viewController;
+            while(presentingViewController.presentedViewController != nil)
+            {
+                presentingViewController = presentingViewController.presentedViewController;
+            }
+            [presentingViewController presentViewController:alertController animated:YES completion:^{
+                [alertList removeObject:alertController];
+            }];
+        });
         
     } else {
 #endif


### PR DESCRIPTION
Now you can stack multiple UIAlertControllers

I had to add a 0.5s delay in case the user tries to present a new
UIAlertController while one is currently being presented (on presenting
animation)