### PR TITLE
CB-9449 - Allow a blank string for dialog titles and messages.

### DIFF
--- a/www/notification.js
+++ b/www/notification.js
@@ -37,7 +37,7 @@ module.exports = {
      * @param {String} buttonLabel          Label of the close button (default: OK)
      */
     alert: function(message, completeCallback, title, buttonLabel) {
-        var _title = (title || "Alert");
+        var _title = (typeof title === "string" ? title : "Alert");
         var _buttonLabel = (buttonLabel || "OK");
         exec(completeCallback, null, "Notification", "alert", [message, _title, _buttonLabel]);
     },
@@ -52,7 +52,7 @@ module.exports = {
      * @param {Array} buttonLabels          Array of the labels of the buttons (default: ['OK', 'Cancel'])
      */
     confirm: function(message, resultCallback, title, buttonLabels) {
-        var _title = (title || "Confirm");
+        var _title = (typeof title === "string" ? title : "Confirm");
         var _buttonLabels = (buttonLabels || ["OK", "Cancel"]);
 
         // Strings are deprecated!
@@ -92,8 +92,8 @@ module.exports = {
      * @param {String} defaultText          Textbox input value (default: empty string)
      */
     prompt: function(message, resultCallback, title, buttonLabels, defaultText) {
-        var _message = (message || "Prompt message");
-        var _title = (title || "Prompt");
+        var _message = (typeof message === "string" ? message : "Prompt message");
+        var _title = (typeof title === "string" ? title : "Prompt");
         var _buttonLabels = (buttonLabels || ["OK","Cancel"]);
         var _defaultText = (defaultText || "");
         exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText]);


### PR DESCRIPTION
Currently there is no way to create a dialog in the Cordova Dialogs plugin without a title. Providing an empty string as the title for any of alert, confirm, or prompt results in a non-localized default title. This makes it impossible to show message-only dialogs on platforms that support such a thing, like iOS. Currently, all dialogs must have a title and additionally prompts must have a message, whether they are provided by the developer or forced by the plugin.

### No workarounds

There are no known workarounds. One that came to mind was passing a space character `navigator.notification.alert('message', null, ' ');` but on iOS this results in a blank space for the title at the top of the alert. Sending an object that will evaluate to true but return a blank string when stringified causes the app to crash `navigator.notification.alert('message', null, {toString: function() { return ''; }});`

### Solution

Rather than testing whether title is falsy to set the default, test whether it is a string, regardless of whether it is a falsy empty string.

### Breaking change?

Requiring the title to be a string prevents numeric and other values from being used, while previously they were passed through to the native plugin. This is a *good thing* because sending anything other than a string causes the plugin to crash the app (at least on iOS), so despite being more restrictive about the data type, I do not consider it a breaking change.