### PR TITLE
set cancelable to false by default on Android

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -163,7 +163,7 @@ public class Notification extends CordovaPlugin {
                 AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
-                dlg.setCancelable(true);
+                dlg.setCancelable(false);
                 dlg.setPositiveButton(buttonLabel,
                         new AlertDialog.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
@@ -203,7 +203,7 @@ public class Notification extends CordovaPlugin {
                 AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
-                dlg.setCancelable(true);
+                dlg.setCancelable(false);
 
                 // First button
                 if (buttonLabels.length() > 0) {
@@ -280,7 +280,7 @@ public class Notification extends CordovaPlugin {
                 AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
-                dlg.setCancelable(true);
+                dlg.setCancelable(false);
                 
                 dlg.setView(promptInput);
                 
@@ -371,7 +371,7 @@ public class Notification extends CordovaPlugin {
                 notification.spinnerDialog = createProgressDialog(cordova); // new ProgressDialog(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 notification.spinnerDialog.setTitle(title);
                 notification.spinnerDialog.setMessage(message);
-                notification.spinnerDialog.setCancelable(true);
+                notification.spinnerDialog.setCancelable(false);
                 notification.spinnerDialog.setIndeterminate(true);
                 notification.spinnerDialog.setOnCancelListener(
                         new DialogInterface.OnCancelListener() {
@@ -414,7 +414,7 @@ public class Notification extends CordovaPlugin {
                 notification.progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
                 notification.progressDialog.setTitle(title);
                 notification.progressDialog.setMessage(message);
-                notification.progressDialog.setCancelable(true);
+                notification.progressDialog.setCancelable(false);
                 notification.progressDialog.setMax(100);
                 notification.progressDialog.setProgress(0);
                 notification.progressDialog.setOnCancelListener(


### PR DESCRIPTION
To match with the iOS behavior where all modals cannot be canceled by a click outside of it (or a back button).
First of all, there is few case where it is interesting for the developper to let the user dismiss the modal by a simple click outside of the modal. And it's absolutely not user friendly, the user does not attempt to see the modal closing after this action. He can cancel it unintentionally.

Maybe a setting would be a great solution too ?

Here some testimonies of developers that have trouble with this (not only with cordova) :
https://github.com/jquery/jquery-mobile/issues/4727
http://stackoverflow.com/questions/23300122/prevent-phonegap-notification-navigator-popups-from-closing-from-touch-outside-o
http://programming.nullanswer.com/question/27626010
http://iswwwup.com/t/5fcbb227c8f7/javascript-prevent-kendo-tooltip-hide-close-when-clicking-outside-the-tooltip.html