### PR TITLE
On iOS8+ allow this dialog to be presented from alternate web views.

### DIFF
--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -95,8 +95,16 @@ static void soundCompletionCallback(SystemSoundID ssid, void* data);
         }
         
         
-        
-        [self.viewController presentViewController:alertController animated:YES completion:nil];
+        UIViewController *currentViewController = [[[UIApplication sharedApplication] delegate] window].rootViewController;
+
+        if (currentViewController) {
+            while (currentViewController.presentedViewController){
+                currentViewController = currentViewController.presentedViewController;
+            }
+            [currentViewController presentViewController:alertController animated:YES completion:nil];
+        } else {
+            [self.viewController presentViewController:alertController animated:YES completion:nil];
+        }
         
     } else {
 #endif


### PR DESCRIPTION
 - On iOS8+ allow this dialog to be presented from alternate web views such as the Cordova InAppBrowser.  Finds the current VC to present the alert on.