### PR TITLE
Fixes Samsung Galaxy S5 cancelling on touch outside

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -475,6 +475,10 @@ public class Notification extends CordovaPlugin {
         int currentapiVersion = android.os.Build.VERSION.SDK_INT;
         dlg.create();
         AlertDialog dialog =  dlg.show();
+
+	// Fix for Samsung Galaxy S5 not dismissing the popup when touching outside.
+	dialog.setCanceledOnTouchOutside(true);
+
         if (currentapiVersion >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
             TextView messageview = (TextView)dialog.findViewById(android.R.id.message);
             messageview.setTextDirection(android.view.View.TEXT_DIRECTION_LOCALE);


### PR DESCRIPTION
On Samsung Galaxy S5 (tested on Android 5.0) a touch outside the AlertDialog won't make it disappear without this line of code added.