### PR TITLE
add CSS class to prompt div for windows platform

### DIFF
--- a/src/windows/NotificationProxy.js
+++ b/src/windows/NotificationProxy.js
@@ -44,6 +44,7 @@ function createPromptDialog(title, message, buttons, defaultText, callback) {
     dlgWrap.style.height = "100%";
     dlgWrap.style.backgroundColor = "rgba(0,0,0,0.25)";
     dlgWrap.style.zIndex = "100000";
+    dlgWrap.className = "dlgWrap";
 
     var dlg = document.createElement("div");
     dlg.style.width = "100%";


### PR DESCRIPTION
As the prompt dialog does not show correctly in our application, we need to style the `div` wrapper element. With this simple change we can apply custom styles in our stylesheet.