### PR TITLE
Added options to customize keyboard for prompt and theme on Andorid

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -279,7 +279,7 @@ public class Notification extends CordovaPlugin {
      * @param buttonLabels      A comma separated list of button labels (Up to 3 buttons)
      * @param callbackContext   The callback context.
      */
-    public synchronized void prompt(final String message, final String title, final JSONArray buttonLabels, final String defaultText, final int theme, final int inputType, final CallbackContext callbackContext) {
+    public synchronized void prompt(final String message, final String title, final JSONArray buttonLabels, final String defaultText, final int inputType, final int theme, final CallbackContext callbackContext) {
 
         final CordovaInterface cordova = this.cordova;
 

--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -90,7 +90,7 @@ public class Notification extends CordovaPlugin {
             return true;
         }
         else if (action.equals("prompt")) {
-            this.prompt(args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), args.getInt(3), callbackContext);
+            this.prompt(args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), args.getInt(4), args.getInt(5), callbackContext);
             return true;
         }
         else if (action.equals("activityStart")) {
@@ -279,7 +279,7 @@ public class Notification extends CordovaPlugin {
      * @param buttonLabels      A comma separated list of button labels (Up to 3 buttons)
      * @param callbackContext   The callback context.
      */
-    public synchronized void prompt(final String message, final String title, final JSONArray buttonLabels, final String defaultText, final int theme, final CallbackContext callbackContext) {
+    public synchronized void prompt(final String message, final String title, final JSONArray buttonLabels, final String defaultText, final int theme, final int inputType, final CallbackContext callbackContext) {
 
         final CordovaInterface cordova = this.cordova;
 
@@ -287,6 +287,7 @@ public class Notification extends CordovaPlugin {
             public void run() {
                 final EditText promptInput =  new EditText(cordova.getActivity());
                 promptInput.setHint(defaultText);
+                promptInput.setInputType(inputType);
                 AlertDialog.Builder dlg = createDialog(cordova, theme); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);

--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -496,7 +496,7 @@ public class Notification extends CordovaPlugin {
     }
 
     @SuppressLint("NewApi")
-    private void changeTextDirection(Builder dlg, View view){
+    private void changeTextDirection(Builder dlg, TextView view){
         int currentapiVersion = android.os.Build.VERSION.SDK_INT;
 
         if (view != null) {
@@ -506,13 +506,14 @@ public class Notification extends CordovaPlugin {
         dlg.create();
 
         final AlertDialog dialog =  dlg.show();
+        TextView messageView = (TextView)dialog.findViewById(android.R.id.message);
 
         if (currentapiVersion >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            TextView messageview = (TextView)dialog.findViewById(android.R.id.message);
-            messageview.setTextDirection(android.view.View.TEXT_DIRECTION_LOCALE);
+            messageView.setTextDirection(android.view.View.TEXT_DIRECTION_LOCALE);
         }
 
         if (view != null) {
+            view.setTextColor(messageView.getTextColors());
             view.setOnFocusChangeListener(new View.OnFocusChangeListener() {
                 @Override
                 public void onFocusChange(View v, boolean hasFocus) {

--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -42,7 +42,7 @@ import android.widget.TextView;
 /**
  * This class provides access to notifications on the device.
  *
- * Be aware that this implementation gets called on 
+ * Be aware that this implementation gets called on
  * navigator.notification.{alert|confirm|prompt}, and that there is a separate
  * implementation in org.apache.cordova.CordovaChromeClient that gets
  * called on a simple window.{alert|confirm|prompt}.
@@ -50,7 +50,7 @@ import android.widget.TextView;
 public class Notification extends CordovaPlugin {
 
     private static final String LOG_TAG = "Notification";
-    
+
     public int confirmResult = -1;
     public ProgressDialog spinnerDialog = null;
     public ProgressDialog progressDialog = null;
@@ -77,20 +77,20 @@ public class Notification extends CordovaPlugin {
     	 * be returned in the event of an invalid action.
     	 */
     	if(this.cordova.getActivity().isFinishing()) return true;
-    	
+
         if (action.equals("beep")) {
             this.beep(args.getLong(0));
         }
         else if (action.equals("alert")) {
-            this.alert(args.getString(0), args.getString(1), args.getString(2), callbackContext);
+            this.alert(args.getString(0), args.getString(1), args.getString(2), args.getInt(3), callbackContext);
             return true;
         }
         else if (action.equals("confirm")) {
-            this.confirm(args.getString(0), args.getString(1), args.getJSONArray(2), callbackContext);
+            this.confirm(args.getString(0), args.getString(1), args.getJSONArray(2), args.getInt(3), callbackContext);
             return true;
         }
         else if (action.equals("prompt")) {
-            this.prompt(args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), callbackContext);
+            this.prompt(args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), args.getInt(3), callbackContext);
             return true;
         }
         else if (action.equals("activityStart")) {
@@ -158,13 +158,13 @@ public class Notification extends CordovaPlugin {
      * @param buttonLabel       The label of the button
      * @param callbackContext   The callback context
      */
-    public synchronized void alert(final String message, final String title, final String buttonLabel, final CallbackContext callbackContext) {
+    public synchronized void alert(final String message, final String title, final String buttonLabel, final int theme, final CallbackContext callbackContext) {
     	final CordovaInterface cordova = this.cordova;
 
         Runnable runnable = new Runnable() {
             public void run() {
 
-                AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+                AlertDialog.Builder dlg = createDialog(cordova, theme); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
                 dlg.setCancelable(true);
@@ -199,12 +199,12 @@ public class Notification extends CordovaPlugin {
      * @param buttonLabels      A comma separated list of button labels (Up to 3 buttons)
      * @param callbackContext   The callback context.
      */
-    public synchronized void confirm(final String message, final String title, final JSONArray buttonLabels, final CallbackContext callbackContext) {
+    public synchronized void confirm(final String message, final String title, final JSONArray buttonLabels, final int theme, final CallbackContext callbackContext) {
     	final CordovaInterface cordova = this.cordova;
 
         Runnable runnable = new Runnable() {
             public void run() {
-                AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+                AlertDialog.Builder dlg = createDialog(cordova, theme); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
                 dlg.setCancelable(true);
@@ -279,23 +279,23 @@ public class Notification extends CordovaPlugin {
      * @param buttonLabels      A comma separated list of button labels (Up to 3 buttons)
      * @param callbackContext   The callback context.
      */
-    public synchronized void prompt(final String message, final String title, final JSONArray buttonLabels, final String defaultText, final CallbackContext callbackContext) {
-  	
+    public synchronized void prompt(final String message, final String title, final JSONArray buttonLabels, final String defaultText, final int theme, final CallbackContext callbackContext) {
+
         final CordovaInterface cordova = this.cordova;
-       
+
         Runnable runnable = new Runnable() {
             public void run() {
                 final EditText promptInput =  new EditText(cordova.getActivity());
                 promptInput.setHint(defaultText);
-                AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+                AlertDialog.Builder dlg = createDialog(cordova, theme); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
                 dlg.setCancelable(true);
-                
+
                 dlg.setView(promptInput);
-                
+
                 final JSONObject result = new JSONObject();
-                
+
                 // First button
                 if (buttonLabels.length() > 0) {
                     try {
@@ -305,7 +305,7 @@ public class Notification extends CordovaPlugin {
                                     dialog.dismiss();
                                     try {
                                         result.put("buttonIndex",1);
-                                        result.put("input1", promptInput.getText().toString().trim().length()==0 ? defaultText : promptInput.getText());											
+                                        result.put("input1", promptInput.getText().toString().trim().length()==0 ? defaultText : promptInput.getText());
                                     } catch (JSONException e) {
                                         LOG.d(LOG_TAG,"JSONException on first button.", e);
                                     }
@@ -348,7 +348,7 @@ public class Notification extends CordovaPlugin {
                                     try {
                                         result.put("buttonIndex",3);
                                         result.put("input1", promptInput.getText().toString().trim().length()==0 ? defaultText : promptInput.getText());
-                                    } catch (JSONException e) { 
+                                    } catch (JSONException e) {
                                         LOG.d(LOG_TAG,"JSONException on third button.", e);
                                     }
                                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, result));
@@ -471,12 +471,12 @@ public class Notification extends CordovaPlugin {
             this.progressDialog = null;
         }
     }
-    
+
     @SuppressLint("NewApi")
-    private AlertDialog.Builder createDialog(CordovaInterface cordova) {
+    private AlertDialog.Builder createDialog(CordovaInterface cordova, int theme) {
         int currentapiVersion = android.os.Build.VERSION.SDK_INT;
         if (currentapiVersion >= android.os.Build.VERSION_CODES.HONEYCOMB) {
-            return new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+            return new AlertDialog.Builder(cordova.getActivity(), theme);
         } else {
             return new AlertDialog.Builder(cordova.getActivity());
         }
@@ -491,7 +491,7 @@ public class Notification extends CordovaPlugin {
             return new ProgressDialog(cordova.getActivity());
         }
     }
-    
+
     @SuppressLint("NewApi")
     private void changeTextDirection(Builder dlg){
         int currentapiVersion = android.os.Build.VERSION.SDK_INT;

--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -90,7 +90,9 @@ public class Notification extends CordovaPlugin {
             return true;
         }
         else if (action.equals("prompt")) {
-            this.prompt(args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), args.getInt(4), args.getInt(5), callbackContext);
+            int inputType = args.optInt(4, android.text.InputType.TYPE_CLASS_TEXT);
+
+            this.prompt(args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), inputType, args.getInt(5), callbackContext);
             return true;
         }
         else if (action.equals("activityStart")) {

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -91,7 +91,10 @@ static NSMutableArray *alertList = nil;
 
             [alertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
                 textField.text = defaultText;
-                textField.keyboardType = [inputType intValue];
+
+                if (inputType != nil) {
+                    textField.keyboardType = [inputType intValue];
+                }
             }];
         }
 

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -37,26 +37,26 @@ static NSMutableArray *alertList = nil;
  *  callbackId    The commmand callback id.
  *  dialogType    The type of alert view [alert | prompt].
  */
-- (void)showDialogWithMessage:(NSString*)message title:(NSString*)title buttons:(NSArray*)buttons defaultText:(NSString*)defaultText callbackId:(NSString*)callbackId dialogType:(NSString*)dialogType
+- (void)showDialogWithMessage:(NSString*)message title:(NSString*)title buttons:(NSArray*)buttons defaultText:(NSString*)defaultText inputType:(NSNumber*)inputType callbackId:(NSString*)callbackId dialogType:(NSString*)dialogType
 {
-    
+
     int count = (int)[buttons count];
 #ifdef __IPHONE_8_0
     if (NSClassFromString(@"UIAlertController")) {
-        
+
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-        
+
         if ([[[UIDevice currentDevice] systemVersion] floatValue] < 8.3) {
-            
+
             CGRect alertFrame = [UIScreen mainScreen].applicationFrame;
-            
+
             if (UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
                 // swap the values for the app frame since it is now in landscape
                 CGFloat temp = alertFrame.size.width;
                 alertFrame.size.width = alertFrame.size.height;
                 alertFrame.size.height = temp;
             }
-            
+
             alertController.view.frame =  alertFrame;
         }
 
@@ -86,22 +86,23 @@ static NSMutableArray *alertList = nil;
                 [weakNotif.commandDelegate sendPluginResult:result callbackId:callbackId];
             }]];
         }
-        
+
         if ([dialogType isEqualToString:DIALOG_TYPE_PROMPT]) {
-            
+
             [alertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
                 textField.text = defaultText;
+                textField.keyboardType = [inputType intValue];
             }];
         }
-        
+
         if(!alertList)
             alertList = [[NSMutableArray alloc] init];
         [alertList addObject:alertController];
-        
+
         if ([alertList count]==1) {
             [self presentAlertcontroller];
         }
-        
+
     }
     else
     {
@@ -113,26 +114,27 @@ static NSMutableArray *alertList = nil;
                                    delegate:self
                                    cancelButtonTitle:nil
                                    otherButtonTitles:nil];
-        
+
         alertView.callbackId = callbackId;
-        
-        
-        
+
+
+
         for (int n = 0; n < count; n++) {
             [alertView addButtonWithTitle:[buttons objectAtIndex:n]];
         }
-        
+
         if ([dialogType isEqualToString:DIALOG_TYPE_PROMPT]) {
             alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
             UITextField* textField = [alertView textFieldAtIndex:0];
             textField.text = defaultText;
+            textField.keyboardType = [inputType intValue];
         }
-        
+
         [alertView show];
 #ifdef __IPHONE_8_0
     }
 #endif
-    
+
 }
 
 - (void)alert:(CDVInvokedUrlCommand*)command
@@ -142,7 +144,7 @@ static NSMutableArray *alertList = nil;
     NSString* title = [command argumentAtIndex:1];
     NSString* buttons = [command argumentAtIndex:2];
 
-    [self showDialogWithMessage:message title:title buttons:@[buttons] defaultText:nil callbackId:callbackId dialogType:DIALOG_TYPE_ALERT];
+    [self showDialogWithMessage:message title:title buttons:@[buttons] defaultText:nil inputType:nil callbackId:callbackId dialogType:DIALOG_TYPE_ALERT];
 }
 
 - (void)confirm:(CDVInvokedUrlCommand*)command
@@ -152,7 +154,7 @@ static NSMutableArray *alertList = nil;
     NSString* title = [command argumentAtIndex:1];
     NSArray* buttons = [command argumentAtIndex:2];
 
-    [self showDialogWithMessage:message title:title buttons:buttons defaultText:nil callbackId:callbackId dialogType:DIALOG_TYPE_ALERT];
+    [self showDialogWithMessage:message title:title buttons:buttons defaultText:nil inputType:nil callbackId:callbackId dialogType:DIALOG_TYPE_ALERT];
 }
 
 - (void)prompt:(CDVInvokedUrlCommand*)command
@@ -162,8 +164,9 @@ static NSMutableArray *alertList = nil;
     NSString* title = [command argumentAtIndex:1];
     NSArray* buttons = [command argumentAtIndex:2];
     NSString* defaultText = [command argumentAtIndex:3];
+    NSNumber* inputType = [command argumentAtIndex:4];
 
-    [self showDialogWithMessage:message title:title buttons:buttons defaultText:defaultText callbackId:callbackId dialogType:DIALOG_TYPE_PROMPT];
+    [self showDialogWithMessage:message title:title buttons:buttons defaultText:defaultText inputType:inputType callbackId:callbackId dialogType:DIALOG_TYPE_PROMPT];
 }
 
 /**
@@ -228,7 +231,7 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
 }
 
 -(void)presentAlertcontroller {
-    
+
     __weak CDVNotification* weakNotif = self;
     [self.getTopPresentedViewController presentViewController:[alertList firstObject] animated:YES completion:^{
         [alertList removeObject:[alertList firstObject]];
@@ -236,7 +239,7 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
             [weakNotif presentAlertcontroller];
         }
     }];
-    
+
 }
 
 @end

--- a/www/notification.js
+++ b/www/notification.js
@@ -91,12 +91,12 @@ module.exports = {
      * @param {Array} buttonLabels          Array of strings for the button labels (default: ["OK","Cancel"])
      * @param {String} defaultText          Textbox input value (default: empty string)
      */
-    prompt: function(message, resultCallback, title, buttonLabels, defaultText, theme, inputType) {
+    prompt: function(message, resultCallback, title, buttonLabels, defaultText, inputType, theme) {
         var _message = (typeof message === "string" ? message : "Prompt message");
         var _title = (typeof title === "string" ? title : "Prompt");
         var _buttonLabels = (buttonLabels || ["OK","Cancel"]);
         var _defaultText = (defaultText || "");
-        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText, theme || 1, inputType || 1]);
+        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText, inputType || 1, theme || 1]);
     },
 
     /**

--- a/www/notification.js
+++ b/www/notification.js
@@ -36,10 +36,10 @@ module.exports = {
      * @param {String} title                Title of the alert dialog (default: Alert)
      * @param {String} buttonLabel          Label of the close button (default: OK)
      */
-    alert: function(message, completeCallback, title, buttonLabel) {
+    alert: function(message, completeCallback, title, buttonLabel, theme) {
         var _title = (typeof title === "string" ? title : "Alert");
         var _buttonLabel = (buttonLabel || "OK");
-        exec(completeCallback, null, "Notification", "alert", [message, _title, _buttonLabel]);
+        exec(completeCallback, null, "Notification", "alert", [message, _title, _buttonLabel, theme || 1]);
     },
 
     /**
@@ -51,7 +51,7 @@ module.exports = {
      * @param {String} title                Title of the alert dialog (default: Confirm)
      * @param {Array} buttonLabels          Array of the labels of the buttons (default: ['OK', 'Cancel'])
      */
-    confirm: function(message, resultCallback, title, buttonLabels) {
+    confirm: function(message, resultCallback, title, buttonLabels, theme) {
         var _title = (typeof title === "string" ? title : "Confirm");
         var _buttonLabels = (buttonLabels || ["OK", "Cancel"]);
 
@@ -76,7 +76,7 @@ module.exports = {
                 _buttonLabels = buttonLabelArray.toString();
             }
         }
-        exec(resultCallback, null, "Notification", "confirm", [message, _title, _buttonLabels]);
+        exec(resultCallback, null, "Notification", "confirm", [message, _title, _buttonLabels, theme || 1]);
     },
 
     /**
@@ -91,12 +91,12 @@ module.exports = {
      * @param {Array} buttonLabels          Array of strings for the button labels (default: ["OK","Cancel"])
      * @param {String} defaultText          Textbox input value (default: empty string)
      */
-    prompt: function(message, resultCallback, title, buttonLabels, defaultText) {
+    prompt: function(message, resultCallback, title, buttonLabels, defaultText, theme) {
         var _message = (typeof message === "string" ? message : "Prompt message");
         var _title = (typeof title === "string" ? title : "Prompt");
         var _buttonLabels = (buttonLabels || ["OK","Cancel"]);
         var _defaultText = (defaultText || "");
-        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText]);
+        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText, theme || 1]);
     },
 
     /**

--- a/www/notification.js
+++ b/www/notification.js
@@ -100,7 +100,7 @@ module.exports = {
         var _title = (typeof title === "string" ? title : "Prompt");
         var _buttonLabels = (buttonLabels || ["OK","Cancel"]);
         var _defaultText = (defaultText || "");
-        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText, inputType || 1, theme || 1]);
+        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText, inputType, theme || 1]);
     },
 
     /**

--- a/www/notification.js
+++ b/www/notification.js
@@ -51,7 +51,7 @@ module.exports = {
      * @param {String} title                Title of the alert dialog (default: Confirm)
      * @param {Array} buttonLabels          Array of the labels of the buttons (default: ['OK', 'Cancel'])
      */
-    confirm: function(message, resultCallback, title, buttonLabels, theme) {
+    confirm: function(message, resultCallback, title, buttonLabels, theme, inputType) {
         var _title = (typeof title === "string" ? title : "Confirm");
         var _buttonLabels = (buttonLabels || ["OK", "Cancel"]);
 
@@ -76,7 +76,7 @@ module.exports = {
                 _buttonLabels = buttonLabelArray.toString();
             }
         }
-        exec(resultCallback, null, "Notification", "confirm", [message, _title, _buttonLabels, theme || 1]);
+        exec(resultCallback, null, "Notification", "confirm", [message, _title, _buttonLabels, theme || 1, inputType || 1]);
     },
 
     /**

--- a/www/notification.js
+++ b/www/notification.js
@@ -51,7 +51,7 @@ module.exports = {
      * @param {String} title                Title of the alert dialog (default: Confirm)
      * @param {Array} buttonLabels          Array of the labels of the buttons (default: ['OK', 'Cancel'])
      */
-    confirm: function(message, resultCallback, title, buttonLabels, theme, inputType) {
+    confirm: function(message, resultCallback, title, buttonLabels, theme) {
         var _title = (typeof title === "string" ? title : "Confirm");
         var _buttonLabels = (buttonLabels || ["OK", "Cancel"]);
 
@@ -76,7 +76,7 @@ module.exports = {
                 _buttonLabels = buttonLabelArray.toString();
             }
         }
-        exec(resultCallback, null, "Notification", "confirm", [message, _title, _buttonLabels, theme || 1, inputType || 1]);
+        exec(resultCallback, null, "Notification", "confirm", [message, _title, _buttonLabels, theme || 1]);
     },
 
     /**
@@ -91,12 +91,12 @@ module.exports = {
      * @param {Array} buttonLabels          Array of strings for the button labels (default: ["OK","Cancel"])
      * @param {String} defaultText          Textbox input value (default: empty string)
      */
-    prompt: function(message, resultCallback, title, buttonLabels, defaultText, theme) {
+    prompt: function(message, resultCallback, title, buttonLabels, defaultText, theme, inputType) {
         var _message = (typeof message === "string" ? message : "Prompt message");
         var _title = (typeof title === "string" ? title : "Prompt");
         var _buttonLabels = (buttonLabels || ["OK","Cancel"]);
         var _defaultText = (defaultText || "");
-        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText, theme || 1]);
+        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText, theme || 1, inputType || 1]);
     },
 
     /**

--- a/www/notification.js
+++ b/www/notification.js
@@ -90,6 +90,10 @@ module.exports = {
      * @param {String} title                Title of the dialog (default: "Prompt")
      * @param {Array} buttonLabels          Array of strings for the button labels (default: ["OK","Cancel"])
      * @param {String} defaultText          Textbox input value (default: empty string)
+     * @param {Number} inputType            Platform-specific value to customize keyboard for the input
+     *
+     * @see http://developer.android.com/reference/android/text/InputType.html
+     * @see https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/#//apple_ref/c/tdef/UIKeyboardType
      */
     prompt: function(message, resultCallback, title, buttonLabels, defaultText, inputType, theme) {
         var _message = (typeof message === "string" ? message : "Prompt message");


### PR DESCRIPTION
Hi. I found that ability to customize keyboard on the `prompt` dialog is very useful. For example, if you expect a user to enter PIN code or phone number you do not need letters etc. There are [some](https://github.com/Paldom/PinDialog) [plugins](https://www.npmjs.com/package/cordova-plugin-number-dialog) that aim to solve this problem, but the solution they provide is limited. I prefer flexibility.

Every platform has its own mechanic to customize keyboard for a text input, but at least Android and iOS have common part - both use some kind of `flags` parameter (check http://developer.android.com/reference/android/text/InputType.html and https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/#//apple_ref/c/tdef/UIKeyboardType). I've done very basic implementation and put extra parameter `inputType` which is of course a platform specific.

This is how you can implement a prompt for a phone number:

``` js
navigator.notification.promptPhone = function(message, callback, dialogTitle, buttonLabels, defaultText) {
  var inputType;

  if (cordova.platformId === "ios") {
    inputType = 5;
  } else if (cordova.platformId === "android") {
    inputType = 3;
  }

  return navigator.notification.prompt(message, callback, dialogTitle, buttonLabels, defaultText, inputType);
}
```

I think the implementation can be improved, because I haven't done anything for other platforms. So feel free to make your comments.
