### PR TITLE
CB-10097 dialog doesn't show on iOS when called from a select list onChange event

### DIFF
--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -220,7 +220,7 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
 
 -(UIViewController *)getTopPresentedViewController {
     UIViewController *presentingViewController = self.viewController;
-    while(presentingViewController.presentedViewController != nil)
+    while(presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed])
     {
         presentingViewController = presentingViewController.presentedViewController;
     }


### PR DESCRIPTION
Changed getTopPresentedViewController to not set the
presentingViewController to a ViewController that is being dismissed.