### PR TITLE
[Windows] Separated CSS from JS code. Fixed prompt UI

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,13 +41,13 @@
             </feature>
         </config-file>                                         
         
-		<asset src="www/firefoxos/notification.css" target="css/notification.css" />
-		<asset src="www/firefoxos/danger-press.png" target="img/danger-press.png" />
-		<asset src="www/firefoxos/danger.png" target="img/danger.png" />
-		<asset src="www/firefoxos/default.png" target="img/default.png" />
-		<asset src="www/firefoxos/gradient.png" target="img/gradient.png" />
-		<asset src="www/firefoxos/pattern.png" target="img/pattern.png" />
-		<asset src="www/firefoxos/recommend.png" target="img/recommend.png" />
+        <asset src="www/firefoxos/notification.css" target="css/notification.css" />
+        <asset src="www/firefoxos/danger-press.png" target="img/danger-press.png" />
+        <asset src="www/firefoxos/danger.png" target="img/danger.png" />
+        <asset src="www/firefoxos/default.png" target="img/default.png" />
+        <asset src="www/firefoxos/gradient.png" target="img/gradient.png" />
+        <asset src="www/firefoxos/pattern.png" target="img/pattern.png" />
+        <asset src="www/firefoxos/recommend.png" target="img/recommend.png" />
         <js-module src="src/firefoxos/notification.js" name="dialogs-impl">
           <runs />
         </js-module>
@@ -110,9 +110,9 @@
             </feature>
         </config-file>
         <header-file src="src/ios/CDVNotification.h" />
-	    <source-file src="src/ios/CDVNotification.m" />
-	    <resource-file src="src/ios/CDVNotification.bundle" />
-		<framework src="AudioToolbox.framework" weak="true" />
+        <source-file src="src/ios/CDVNotification.m" />
+        <resource-file src="src/ios/CDVNotification.bundle" />
+        <framework src="AudioToolbox.framework" weak="true" />
     </platform>
 
     <!-- blackberry10 -->
@@ -167,5 +167,7 @@
         <js-module src="src/windows/NotificationProxy.js" name="NotificationProxy">
             <merges target="" />
         </js-module>
+
+        <asset src="www/windows/notification.css" target="css/notification.css" />
     </platform>
 </plugin>

--- a/www/windows/notification.css
+++ b/www/windows/notification.css
@@ -1,0 +1,63 @@
+.dlgWrap {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.25);
+    z-index: 100000;
+    top: 0;
+}
+
+.dlgContainer {
+    width: 100%;
+    min-height: 180px;
+    height: auto;
+    overflow: auto;
+    background-color: white;
+    position: relative;
+    line-height: 2;
+    top: 50%;
+    transform: translateY(-50%);
+    padding: 0 30%;
+}
+
+.dlgContainer #lbl-title {
+    font-size: 24pt;
+}
+
+.dlgContainer #prompt-input {
+    width: 100%;
+}
+
+.dlgButton {
+    margin: 8px 0 0 16px;
+    float: right;
+    font-size: 11pt;
+    background-color: #cccccc;
+    border: none;
+    font-weight: 600;
+    font-family: "Segoe UI", Arial, sans-serif;
+    padding: 0 22px;
+}
+
+.dlgButton.dlgButtonFirst {
+    color: white;
+    background-color: #464646;
+}
+
+.dlgContainer.dlgContainer-windows {
+    width: 50%;
+    max-width: 680px;
+    padding: 0 5%;
+    top: 50%;
+    left: 50%;
+    position: fixed;
+    transform: translate(-50%, -50%);
+    border: 1px solid rgb(24, 160, 191);
+    border-image: none;
+    box-shadow: 0 0 14px 6px rgba(0,0,0,0.16);
+    text-transform: none;
+}
+
+.dlgContainer.dlgContainer-phone {
+    padding: 0 5%;
+}


### PR DESCRIPTION
Fixed the prompt dialog CSS to look close to native.
Fixed the positioning of the prompt dialog for Windows.

**How to test**

1. cordova create myApp
1. cordova platform add windows --save
1. cordova plugin add https://github.com/serbanghita/cordova-plugin-dialogs.git
1. cordova build windows

I added `dialogs.js` demo file to the default `index.html` file. Contents of my manual tests: https://gist.github.com/serbanghita/75de9758eada643ce9823dfa02730066

Here are `prompt` which is close to native `confirm` and `alert` now.

<img width="374" alt="prompt-fix" src="https://cloud.githubusercontent.com/assets/1106849/15019242/ef4c683c-1225-11e6-9bd2-14c14331c613.PNG">
<img width="380" alt="confirm-native" src="https://cloud.githubusercontent.com/assets/1106849/15019245/f3f0e62e-1225-11e6-9f64-f32c622714f1.PNG">
