### PR TITLE
CB-11281 windows: defaultText is taken as input for empty input field

### DIFF
--- a/src/windows/NotificationProxy.js
+++ b/src/windows/NotificationProxy.js
@@ -74,7 +74,7 @@ function createPromptDialog(title, message, buttons, defaultText, callback) {
 
     function makeButtonCallback(idx) {
         return function () {
-            var value = dlg.querySelector('#prompt-input').value;
+            var value = dlg.querySelector('#prompt-input').value || defaultText;
             dlgWrap.parentNode.removeChild(dlgWrap);
 
             if (callback) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -114,7 +114,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
             buttons);
     };
 
-    var promptDialog = function (message, title, buttons) {
+    var promptDialog = function (message, title, buttons,defaultText) {
         clearLog();
         navigator.notification.prompt(message,
             function (r) {
@@ -131,7 +131,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
                 }
             },
             title,
-            buttons);
+            buttons,defaultText);
     };
 
     /******************************************************************************/
@@ -147,7 +147,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         '<p/> <div id="confirm"></div>' +
         'Expected result: Dialog will say "You pressed confirm". Press Yes, No, or Maybe, Not Sure to close dialog. Status box will tell you what option you selected, and should use 1-based indexing.' +
         '<p/> <div id="prompt"></div>' +
-        'Expected result: Dialog will say "You pressed prompt". Enter any message and press Yes, No, or Maybe, Not Sure to close dialog. Status box will tell you what option you selected and message you entered, and should use 1-based indexing.' +
+        'Expected result: Dialog will say "You pressed prompt". Enter any message and press Yes, No, or Maybe, Not Sure to close dialog. Status box will tell you what option you selected and message you entered or if empty, it will display "Default Text", and should use 1-based indexing.' +
         '<p/> <div id="built_in_alert"></div>' +
         'Expected result: Dialog will have title "index.html" and say "You pressed alert" Press OK to close dialog. Nothing will get updated in status box.' +
         '<p/> <div id="built_in_confirm"></div>' +
@@ -182,7 +182,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     }, 'confirm');
 
     createActionButton('Prompt Dialog', function () {
-        promptDialog('You pressed prompt.', 'Prompt Dialog', ['Yes', 'No', 'Maybe, Not Sure']);
+        promptDialog('You pressed prompt.', 'Prompt Dialog', ['Yes', 'No', 'Maybe, Not Sure'],'Default Text');
     }, 'prompt');
 
     createActionButton('Built-in Alert Dialog', function () {


### PR DESCRIPTION


### Platforms affected
Windows

### What does this PR do?
CB-11281 issue fixed. If there is no input by user in prompt dialog, default text is not taken as input. That issue is fixed.
