### PR TITLE
/!\ Alert on startapp

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,6 @@ Thanks!
 
 
 ### Checklist
-- [ ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
 - [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
 - [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
 - [ ] Added automated test coverage as appropriate for this change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-dialogs",
-  "version": "1.3.0",
+  "version": "1.3.1-dev",
   "description": "Cordova Notification Plugin",
   "cordova": {
     "id": "cordova-plugin-dialogs",

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-dialogs"
-      version="1.3.0">
+      version="1.3.1-dev">
 
     <name>Notification</name>
     <description>Cordova Notification Plugin</description>

--- a/src/windows/NotificationProxy.js
+++ b/src/windows/NotificationProxy.js
@@ -116,6 +116,13 @@ function createPromptDialog(title, message, buttons, defaultText, callback) {
 
     // make sure input field is under focus
     dlg.querySelector('#prompt-input').select();
+    // add Enter/Return key handling
+    var defaultButton = dlg.querySelector(".dlgButtonFirst");
+    dlg.addEventListener("keypress",function(e) {
+        if (e.keyCode === 13) { // enter key
+            defaultButton && defaultButton.click();
+        }
+    });
 
     return dlgWrap;
 }

--- a/src/windows/NotificationProxy.js
+++ b/src/windows/NotificationProxy.js
@@ -120,7 +120,9 @@ function createPromptDialog(title, message, buttons, defaultText, callback) {
     var defaultButton = dlg.querySelector(".dlgButtonFirst");
     dlg.addEventListener("keypress",function(e) {
         if (e.keyCode === 13) { // enter key
-            defaultButton && defaultButton.click();
+            if(defaultButton) {
+                defaultButton.click();
+            }
         }
     });
 

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-dialogs-tests"
-    version="1.3.0">
+    version="1.3.1-dev">
     <name>Cordova Notification Plugin Tests</name>
     <license>Apache 2.0</license>
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -185,6 +185,10 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         promptDialog('You pressed prompt.', 'Prompt Dialog', ['Yes', 'No', 'Maybe, Not Sure'],'Default Text');
     }, 'prompt');
 
+    createActionButton('Prompt Dialog - no default', function () {
+        promptDialog('You pressed prompt.', 'Prompt Dialog', ['Yes', 'No']);
+    }, 'prompt');    
+
     createActionButton('Built-in Alert Dialog', function () {
         if (typeof alert === 'function') {
             alert('You pressed alert');

--- a/www/notification.js
+++ b/www/notification.js
@@ -39,7 +39,7 @@ module.exports = {
     alert: function(message, completeCallback, title, buttonLabel) {
         var _message = (typeof message === "string" ? message : JSON.stringify(message));
         var _title = (typeof title === "string" ? title : "Alert");
-        var _buttonLabel = (buttonLabel || "OK");
+        var _buttonLabel = (typeof buttonLabel === "string" ? buttonLabel : "OK");
         exec(completeCallback, null, "Notification", "alert", [_message, _title, _buttonLabel]);
     },
 

--- a/www/notification.js
+++ b/www/notification.js
@@ -39,7 +39,7 @@ module.exports = {
     alert: function(message, completeCallback, title, buttonLabel) {
         var _message = (typeof message === "string" ? message : JSON.stringify(message));
         var _title = (typeof title === "string" ? title : "Alert");
-        var _buttonLabel = (typeof buttonLabel === "string" ? buttonLabel : "OK");
+        var _buttonLabel = (buttonLabel && typeof buttonLabel === "string" ? buttonLabel : "OK");
         exec(completeCallback, null, "Notification", "alert", [_message, _title, _buttonLabel]);
     },
 


### PR DESCRIPTION
Hello , i have problem since i updated platform ios on cordova .
i use this code on my onDeviceready() 
`		if (navigator.notification) { // Override default HTML alert with native dialog
			window.alert = function (message) {
			  navigator.notification.alert(
			      message,    // message
			      null,       // callback
			      getText('application-title'), // title
			      getText('ok')        // buttonName
			  );
			 };
		}`
no problem before update. But after update ios platform and this plugin , i always have an alert with message "1" . I do not know how to remove this alert . Can anyone solve my problem?