### PR TITLE
CB-13555 (ios) Present notification view controller by inappbrowser view controller

### DIFF
--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -231,16 +231,10 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
     if (presentingViewController.view.window != [UIApplication sharedApplication].keyWindow){
         //for wkwebview, the privacy screen plugin is presented from a different window object
         presentingViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-        while (presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed]){
-            presentingViewController = presentingViewController.presentedViewController;
-        }
     }
-    else {
-        //for uiwebview viewcontroller, if inappbrowser or privacyscreen viewcontroller is presented,
-        //then they should be used to repsent the new view control.
-        while (presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed]){
-            presentingViewController = presentingViewController.presentedViewController;
-        }
+
+    while (presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed]){
+        presentingViewController = presentingViewController.presentedViewController;
     }
     return presentingViewController;
 }

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -228,16 +228,16 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
 
 -(UIViewController *)getTopPresentedViewController {
     UIViewController *presentingViewController = self.viewController;
-    if (presentingViewController.view.window == nil){
-        //for uiwebview viewcontroller, if privacyscreen plugin's viewcontroller is presented, the scanner viewcontroller needs
-        //to be presented by the privacyscreen's viewcontroller.
+    if (presentingViewController.view.window != [UIApplication sharedApplication].keyWindow){
+        //for wkwebview, the privacy screen plugin is presented from a different window object
+        presentingViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
         while (presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed]){
             presentingViewController = presentingViewController.presentedViewController;
         }
     }
-    else if (presentingViewController.view.window != [UIApplication sharedApplication].keyWindow){
-        //for wkwebview, the privacy screen plugin is presented from a different window object
-        presentingViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    else {
+        //for uiwebview viewcontroller, if inappbrowser or privacyscreen viewcontroller is presented,
+        //then they should be used to repsent the new view control.
         while (presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed]){
             presentingViewController = presentingViewController.presentedViewController;
         }

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -228,9 +228,19 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
 
 -(UIViewController *)getTopPresentedViewController {
     UIViewController *presentingViewController = self.viewController;
-    while(presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed])
-    {
-        presentingViewController = presentingViewController.presentedViewController;
+    if (presentingViewController.view.window == nil){
+        //for uiwebview viewcontroller, if privacyscreen plugin's viewcontroller is presented, the scanner viewcontroller needs
+        //to be presented by the privacyscreen's viewcontroller.
+        while (presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed]){
+            presentingViewController = presentingViewController.presentedViewController;
+        }
+    }
+    else if (presentingViewController.view.window != [UIApplication sharedApplication].keyWindow){
+        //for wkwebview, the privacy screen plugin is presented from a different window object
+        presentingViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+        while (presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed]){
+            presentingViewController = presentingViewController.presentedViewController;
+        }
     }
     return presentingViewController;
 }

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -229,7 +229,6 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
 -(UIViewController *)getTopPresentedViewController {
     UIViewController *presentingViewController = self.viewController;
     if (presentingViewController.view.window != [UIApplication sharedApplication].keyWindow){
-        //for wkwebview, the privacy screen plugin is presented from a different window object
         presentingViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
     }
 


### PR DESCRIPTION
…resented

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Fix the issue of not showing the dialog screen if inappbrowser screen is presented
[https://issues.apache.org/jira/browse/CB-13555](https://issues.apache.org/jira/browse/CB-13555)

### What testing has been done on this change?
Create a cordova ios project with UIWebView or WKWebView, and call the below method. The dialog view does not show to user.
```
function confirm(){
    var win = window.open( "https://www.google.com", "_blank" );
    win.addEventListener( "loadstop", function() {
    setTimeout(function() {
         function onConfirm(buttonIndex) {
            console.log('You selected button ' + buttonIndex);
        }
        
        navigator.notification.confirm(
            'You are the winner!', // message
            onConfirm,            // callback to invoke with index of button pressed
            'Game Over',           // title
            ['Restart','Exit']     // buttonLabels
);
    }, 1000 );
});
}
```
### Checklist
- [Y] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [Y] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [N] Added automated test coverage as appropriate for this change.
