### PR TITLE
CB-12129 (android): Add ability to set dialog style

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,62 @@ Report issues on the [Apache Cordova issue tracker](https://issues.apache.org/ji
 
 ## Methods
 
+- `navigator.notification.setAndroidStyleName`
 - `navigator.notification.alert`
 - `navigator.notification.confirm`
 - `navigator.notification.prompt`
 - `navigator.notification.beep`
+
+## navigator.notification.setAndroidStyleName
+
+For Android platforms, allows specifying a custom style name to use with the dialogs.
+The style name can be defined within a `styles.xml` file. The `stles.xml` file
+is referenced in your config.xml file as a `<resource-file>`.
+
+    navigator.notification.setAndroidStyleName(styleName)
+
+- __styleName__: Name of Android style. _(String)_
+
+
+### Example
+
+1. Create a `style.xml` with a custom dialog style (notice we give the style a name of `AlertDialogCustom` which will be used in our code later)(this file can go anywhere in your project, this example places it in the root):
+
+
+    <!-- styles.xml file -->
+    <color name="blue">#0000ff</color>
+    <color name="white">#ffffff</color>
+    <color name="black">#000000</color>
+    <style name="AlertDialogCustom" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <!-- Used for button colors -->
+        <item name="android:colorAccent">@color/blue</item>
+        <!-- Used for the title and text -->
+        <item name="android:textColorPrimary">@color/black</item>
+        <!-- Used for the background -->
+        <item name="android:background">@color/white</item>
+
+        <!-- More styles could be added... -->
+    </style>
+
+2. Reference your `styles.xml` file in your `config.xml` file so it gets copied to the correct location (since we placed `styles.xml` in our root, we just put the filename with no path, otherwise `src` is relative to your `config.xml` directory)
+
+    <!-- config.xml file -->
+    <widget>
+        <platform name="android">
+            <resource-file src="styles.xml" target="app/src/main/res/values/styles.xml" />
+        </platform>
+    </widget>
+
+3. In your code, set the dialog style name to the one you used in `styles.xml`:
+
+
+    navigator.notification.setAndroidStyleName(
+        'AlertDialogCustom'  // styleName
+    );
+
+### Supported Platforms
+
+- Android
 
 ## navigator.notification.alert
 

--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -51,7 +51,9 @@ import android.widget.TextView;
 public class Notification extends CordovaPlugin {
 
     private static final String LOG_TAG = "Notification";
-    
+
+    private String androidStyleName = "";
+
     public int confirmResult = -1;
     public ProgressDialog spinnerDialog = null;
     public ProgressDialog progressDialog = null;
@@ -78,8 +80,11 @@ public class Notification extends CordovaPlugin {
     	 * be returned in the event of an invalid action.
     	 */
     	if(this.cordova.getActivity().isFinishing()) return true;
-    	
-        if (action.equals("beep")) {
+
+        if (action.equals("setAndroidStyleName")) {
+            this.setAndroidStyleName(args.getString(0));
+        }
+        else if (action.equals("beep")) {
             this.beep(args.getLong(0));
         }
         else if (action.equals("alert")) {
@@ -121,6 +126,15 @@ public class Notification extends CordovaPlugin {
     //--------------------------------------------------------------------------
     // LOCAL METHODS
     //--------------------------------------------------------------------------
+
+    /**
+     * Beep plays the default notification ringtone.
+     *
+     * @param styleName     The name of the android xml defined style to override the alert dialog theme (default: THEME_DEVICE_DEFAULT_LIGHT)
+     */
+    public void setAndroidStyleName(final String styleName) {
+        androidStyleName = styleName;
+    }
 
     /**
      * Beep plays the default notification ringtone.
@@ -484,7 +498,9 @@ public class Notification extends CordovaPlugin {
     private AlertDialog.Builder createDialog(CordovaInterface cordova) {
         int currentapiVersion = android.os.Build.VERSION.SDK_INT;
         if (currentapiVersion >= android.os.Build.VERSION_CODES.HONEYCOMB) {
-            return new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+            int id = androidStyleName == null || androidStyleName.isEmpty() ? AlertDialog.THEME_DEVICE_DEFAULT_LIGHT : cordova.getActivity().getResources().getIdentifier(androidStyleName, "style", cordova.getActivity().getPackageName());
+
+            return new AlertDialog.Builder(cordova.getActivity(), id);
         } else {
             return new AlertDialog.Builder(cordova.getActivity());
         }
@@ -494,7 +510,9 @@ public class Notification extends CordovaPlugin {
     private ProgressDialog createProgressDialog(CordovaInterface cordova) {
         int currentapiVersion = android.os.Build.VERSION.SDK_INT;
         if (currentapiVersion >= android.os.Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            return new ProgressDialog(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+            int id = androidStyleName == null || androidStyleName.isEmpty() ? AlertDialog.THEME_DEVICE_DEFAULT_LIGHT : cordova.getActivity().getResources().getIdentifier(androidStyleName, "style", cordova.getActivity().getPackageName());
+
+            return new ProgressDialog(cordova.getActivity(), id);
         } else {
             return new ProgressDialog(cordova.getActivity());
         }

--- a/www/notification.js
+++ b/www/notification.js
@@ -31,6 +31,20 @@ module.exports = {
     /**
      * Open a native alert dialog, with a customizable title and button text.
      *
+     * @param {String} styleName            The name of the android xml defined style to override the alert dialog theme (default: THEME_DEVICE_DEFAULT_LIGHT)
+     */
+    setAndroidStyleName: function (styleName) {
+        if (platform.id !== 'android') {
+            return;
+        }
+
+        const _styleName = (styleName || '');
+        exec(null, null, 'Notification', 'setAndroidStyleName', [_styleName]);
+    },
+
+    /**
+     * Open a native alert dialog, with a customizable title and button text.
+     *
      * @param {String} message              Message to print in the body of the alert
      * @param {Function} completeCallback   The callback that is called when user clicks on a button.
      * @param {String} title                Title of the alert dialog (default: Alert)


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Created new `setAndroidStyleName` function to allow specifying the name of a style to apply to dialogs on Android. Also updated README to explain how to create a named style and copy it to the correct location.

### What testing has been done on this change?
Tested on Android 7.1.1 emulator.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
