### PR TITLE
[MAJOR] GH-28 Progress dialogs should be cancellable outside the window

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -447,6 +447,7 @@ public class Notification extends CordovaPlugin {
                 notification.progressDialog.setCancelable(true);
                 notification.progressDialog.setMax(100);
                 notification.progressDialog.setProgress(0);
+                notification.progressDialog.setCanceledOnTouchOutside(false);
                 notification.progressDialog.setOnCancelListener(
                         new DialogInterface.OnCancelListener() {
                             public void onCancel(DialogInterface dialog) {


### PR DESCRIPTION
Proposal to cherry-pick the fix proposed in PR #28. The change in behavior makes sense to me. I think this change should go into a new major release.

Resolves #28