### PR TITLE
fix(android): Notifications now stop and clears the channel

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -146,6 +146,7 @@ public class Notification extends CordovaPlugin {
                                 Thread.currentThread().interrupt();
                             }
                         }
+                        notification.stop();
                     }
                 }
             }


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Ensures notifications stop after playing. 
This fixes the issue we had when after 15 notifications, the 16th notification would not play the sound.

### What testing has been done on this change?
Use previous version, spam .beep() 16, the 16th notification will not play. 
Use this version, the issue is fixed.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
