### PR TITLE
GH-122 android: Cleanup Dialog plugin code

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -18,15 +18,6 @@
 */
 package org.apache.cordova.dialogs;
 
-import org.apache.cordova.CallbackContext;
-import org.apache.cordova.CordovaInterface;
-import org.apache.cordova.CordovaPlugin;
-import org.apache.cordova.LOG;
-import org.apache.cordova.PluginResult;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
@@ -38,6 +29,15 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.widget.EditText;
 import android.widget.TextView;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.LOG;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 
 /**
@@ -51,6 +51,19 @@ import android.widget.TextView;
 public class Notification extends CordovaPlugin {
 
     private static final String LOG_TAG = "Notification";
+
+    private static final String ACTION_BEEP           = "beep";
+    private static final String ACTION_ALERT          = "alert";
+    private static final String ACTION_CONFIRM        = "confirm";
+    private static final String ACTION_PROMPT         = "prompt";
+    private static final String ACTION_ACTIVITY_START = "activityStart";
+    private static final String ACTION_ACTIVITY_STOP  = "activityStop";
+    private static final String ACTION_PROGRESS_START = "progressStart";
+    private static final String ACTION_PROGRESS_VALUE = "progressValue";
+    private static final String ACTION_PROGRESS_STOP  = "progressStop";
+
+    private static final long BEEP_TIMEOUT   = 5000;
+    private static final long BEEP_WAIT_TINE = 100;
 
     public int confirmResult = -1;
     public ProgressDialog spinnerDialog = null;
@@ -77,36 +90,36 @@ public class Notification extends CordovaPlugin {
     	 * crashing the app. Just return true here since false should only
     	 * be returned in the event of an invalid action.
     	 */
-    	if(this.cordova.getActivity().isFinishing()) return true;
+    	if (this.cordova.getActivity().isFinishing()) return true;
 
-        if (action.equals("beep")) {
+        if (action.equals(ACTION_BEEP)) {
             this.beep(args.getLong(0));
         }
-        else if (action.equals("alert")) {
+        else if (action.equals(ACTION_ALERT)) {
             this.alert(args.getString(0), args.getString(1), args.getString(2), callbackContext);
             return true;
         }
-        else if (action.equals("confirm")) {
+        else if (action.equals(ACTION_CONFIRM)) {
             this.confirm(args.getString(0), args.getString(1), args.getJSONArray(2), callbackContext);
             return true;
         }
-        else if (action.equals("prompt")) {
+        else if (action.equals(ACTION_PROMPT)) {
             this.prompt(args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), callbackContext);
             return true;
         }
-        else if (action.equals("activityStart")) {
+        else if (action.equals(ACTION_ACTIVITY_START)) {
             this.activityStart(args.getString(0), args.getString(1));
         }
-        else if (action.equals("activityStop")) {
+        else if (action.equals(ACTION_ACTIVITY_STOP)) {
             this.activityStop();
         }
-        else if (action.equals("progressStart")) {
+        else if (action.equals(ACTION_PROGRESS_START)) {
             this.progressStart(args.getString(0), args.getString(1));
         }
-        else if (action.equals("progressValue")) {
+        else if (action.equals(ACTION_PROGRESS_VALUE)) {
             this.progressValue(args.getInt(0));
         }
-        else if (action.equals("progressStop")) {
+        else if (action.equals(ACTION_PROGRESS_STOP)) {
             this.progressStop();
         }
         else {
@@ -137,11 +150,11 @@ public class Notification extends CordovaPlugin {
                 if (notification != null) {
                     for (long i = 0; i < count; ++i) {
                         notification.play();
-                        long timeout = 5000;
+                        long timeout = BEEP_TIMEOUT;
                         while (notification.isPlaying() && (timeout > 0)) {
-                            timeout = timeout - 100;
+                            timeout = timeout - BEEP_WAIT_TINE;
                             try {
-                                Thread.sleep(100);
+                                Thread.sleep(BEEP_WAIT_TINE);
                             } catch (InterruptedException e) {
                                 Thread.currentThread().interrupt();
                             }
@@ -165,7 +178,7 @@ public class Notification extends CordovaPlugin {
         Runnable runnable = new Runnable() {
             public void run() {
 
-                AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+                Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
                 dlg.setCancelable(true);
@@ -205,7 +218,7 @@ public class Notification extends CordovaPlugin {
 
         Runnable runnable = new Runnable() {
             public void run() {
-                AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+                Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
                 dlg.setCancelable(true);
@@ -295,7 +308,7 @@ public class Notification extends CordovaPlugin {
                 int promptInputTextColor = resources.getColor(android.R.color.primary_text_light);
                 promptInput.setTextColor(promptInputTextColor);
                 promptInput.setText(defaultText);
-                AlertDialog.Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+                Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
                 dlg.setCancelable(true);
@@ -481,12 +494,12 @@ public class Notification extends CordovaPlugin {
     }
 
     @SuppressLint("NewApi")
-    private AlertDialog.Builder createDialog(CordovaInterface cordova) {
+    private Builder createDialog(CordovaInterface cordova) {
         int currentapiVersion = android.os.Build.VERSION.SDK_INT;
         if (currentapiVersion >= android.os.Build.VERSION_CODES.HONEYCOMB) {
-            return new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+            return new Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
         } else {
-            return new AlertDialog.Builder(cordova.getActivity());
+            return new Builder(cordova.getActivity());
         }
     }
 


### PR DESCRIPTION
### Platforms affected
Android

### Description
1. Organizing Notification imports.
2. Externalizing Action strings in private static finals.
3. Externalizing Beep timeout and wait time in private static finals.

### Testing
Test plugin and everything works fine.

- [x] I've run the tests to see all new and existing tests pass
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))