### PR TITLE
Focus text input in prompt dialog

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -391,6 +391,8 @@ public class Notification extends CordovaPlugin {
                 });
 
                 changeTextDirection(dlg);
+
+                promptInput.requestFocus();
             };
         };
         this.cordova.getActivity().runOnUiThread(runnable);


### PR DESCRIPTION
### Platforms affected

Android 10

### Motivation and Context

Some versions of Android 10 SDK do not automatically focus the EditText control, resulting in a blank, unbordered, input box which is essentially invisible.

### Description

Added 1 line to focus the EditText input in the prompt method.



### Testing

Tested the fix in the android 10 simulator.



### Checklist


- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
