### PR TITLE
(android): Added ability to setCancelable

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -61,6 +61,7 @@ public class Notification extends CordovaPlugin {
     private static final String ACTION_PROGRESS_START = "progressStart";
     private static final String ACTION_PROGRESS_VALUE = "progressValue";
     private static final String ACTION_PROGRESS_STOP  = "progressStop";
+    private static final String ACTION_SET_CANCELABLE  = "setCancelable";
 
     private static final long BEEP_TIMEOUT   = 5000;
     private static final long BEEP_WAIT_TINE = 100;
@@ -68,6 +69,8 @@ public class Notification extends CordovaPlugin {
     public int confirmResult = -1;
     public ProgressDialog spinnerDialog = null;
     public ProgressDialog progressDialog = null;
+
+    private boolean isCancelable = true;
 
     /**
      * Constructor.
@@ -121,6 +124,9 @@ public class Notification extends CordovaPlugin {
         }
         else if (action.equals(ACTION_PROGRESS_STOP)) {
             this.progressStop();
+        }
+        else if (action.equals(ACTION_SET_CANCELABLE)) {
+            this.setCancelable(args.optBoolean(0, true));
         }
         else {
             return false;
@@ -181,7 +187,7 @@ public class Notification extends CordovaPlugin {
                 Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
-                dlg.setCancelable(true);
+                dlg.setCancelable(isCancelable);
                 dlg.setPositiveButton(buttonLabel,
                         new AlertDialog.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
@@ -221,7 +227,7 @@ public class Notification extends CordovaPlugin {
                 Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
-                dlg.setCancelable(true);
+                dlg.setCancelable(isCancelable);
 
                 // First button
                 if (buttonLabels.length() > 0) {
@@ -311,7 +317,7 @@ public class Notification extends CordovaPlugin {
                 Builder dlg = createDialog(cordova); // new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 dlg.setMessage(message);
                 dlg.setTitle(title);
-                dlg.setCancelable(true);
+                dlg.setCancelable(isCancelable);
 
                 dlg.setView(promptInput);
 
@@ -414,7 +420,7 @@ public class Notification extends CordovaPlugin {
                 notification.spinnerDialog = createProgressDialog(cordova); // new ProgressDialog(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 notification.spinnerDialog.setTitle(title);
                 notification.spinnerDialog.setMessage(message);
-                notification.spinnerDialog.setCancelable(true);
+                notification.spinnerDialog.setCancelable(isCancelable);
                 notification.spinnerDialog.setIndeterminate(true);
                 notification.spinnerDialog.setOnCancelListener(
                         new DialogInterface.OnCancelListener() {
@@ -457,7 +463,7 @@ public class Notification extends CordovaPlugin {
                 notification.progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
                 notification.progressDialog.setTitle(title);
                 notification.progressDialog.setMessage(message);
-                notification.progressDialog.setCancelable(true);
+                notification.progressDialog.setCancelable(isCancelable);
                 notification.progressDialog.setMax(100);
                 notification.progressDialog.setProgress(0);
                 notification.progressDialog.setOnCancelListener(
@@ -491,6 +497,10 @@ public class Notification extends CordovaPlugin {
             this.progressDialog.dismiss();
             this.progressDialog = null;
         }
+    }
+
+    public void setCancelable(boolean enable) {
+        this.isCancelable = enable;
     }
 
     @SuppressLint("NewApi")

--- a/www/android/notification.js
+++ b/www/android/notification.js
@@ -70,5 +70,13 @@ module.exports = {
      */
     progressValue: function (value) {
         exec(null, null, 'Notification', 'progressValue', [ value ]);
+    },
+
+    /**
+     * Set whether the user can cancel the dialog
+     * @param {Boolean} enable Enable/Disable cancellable dialog
+     */
+    setCancelable:  function(enable) {
+        exec(null, null, 'Notification', 'setCancelable', [ enable ]);
     }
 };


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
When user taps outside the dialog in Android, it cancels the dialog. This may not be the expected behaviour for some users, since the user has not tap any of the buttons. Resulting in confusion for some users.

This change allows the developer to set globally, whether dialog should be cancelable


### Description
Changes are added specifically for Android platform.

Added a property - isCancelable, to Notification.java class that controls whether new dialogs are cancelable.
Added a function - setCancelable(enable), to set the isCancelable property

