### PR TITLE
breaking(ios): remove CDVAlertView

### DIFF
--- a/src/ios/CDVNotification.h
+++ b/src/ios/CDVNotification.h
@@ -30,8 +30,3 @@
 - (void)beep:(CDVInvokedUrlCommand*)command;
 
 @end
-
-@interface CDVAlertView : UIAlertView {}
-@property (nonatomic, copy) NSString* callbackId;
-
-@end

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -75,8 +75,9 @@ static NSMutableArray *alertList = nil;
             textField.text = defaultText;
         }];
     }
-    if(!alertList)
+    if (!alertList) {
         alertList = [[NSMutableArray alloc] init];
+    }
     [alertList addObject:alertController];
 
     if ([alertList count] == 1) {

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -79,7 +79,7 @@ static NSMutableArray *alertList = nil;
         alertList = [[NSMutableArray alloc] init];
     [alertList addObject:alertController];
 
-    if ([alertList count]==1) {
+    if ([alertList count] == 1) {
         [self presentAlertcontroller];
     }
 }


### PR DESCRIPTION
Breaking because CDVAlertView was used for iOS 7 and older and also removes a patch for a bug of iOS < 8.3. We have not supported them on cordova-ios for a while, so maybe we can consider it non breaking, but just in case.

CDVAlertView was a custom implementation of UIAlertView, which was deprecated on iOS 8.
The plugin already has code to use UIAlertController on iOS 8 and newer, so this just removes the old code.

closes https://github.com/apache/cordova-plugin-dialogs/issues/119