### PR TITLE
fix: remove deprecated platform snippet 

### DIFF
--- a/www/notification.js
+++ b/www/notification.js
@@ -114,16 +114,7 @@ function convertButtonLabels (buttonLabels) {
     // Some platforms take an array of button label names.
     // Other platforms take a comma separated list.
     // For compatibility, we convert to the desired type based on the platform.
-    if (
-        platform.id === 'amazon-fireos' ||
-        platform.id === 'android' ||
-        platform.id === 'ios' ||
-        platform.id === 'windowsphone' ||
-        platform.id === 'firefoxos' ||
-        platform.id === 'ubuntu' ||
-        platform.id === 'windows8' ||
-        platform.id === 'windows'
-    ) {
+    if (platform.id === 'android' || platform.id === 'ios' || platform.id === 'windows') {
         if (typeof buttonLabels === 'string') {
             buttonLabels = buttonLabels.split(','); // not crazy about changing the var type here
         }


### PR DESCRIPTION
### Motivation and Context

Removes forgotten code that should have been removed in https://github.com/apache/cordova-plugin-dialogs/pull/99/

Depends on #141, therefore WIP.