### PR TITLE
breaking: bump version 3.0.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-dialogs",
-  "version": "2.0.3-dev",
+  "version": "3.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-dialogs",
-  "version": "2.0.3-dev",
+  "version": "3.0.0-dev",
   "description": "Cordova Notification Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-dialogs"
-      version="2.0.3-dev">
+      version="3.0.0-dev">
 
     <name>Notification</name>
     <description>Cordova Notification Plugin</description>

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-dialogs-tests",
-  "version": "2.0.3-dev",
+  "version": "3.0.0-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-dialogs-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-dialogs-tests"
-    version="2.0.3-dev">
+    version="3.0.0-dev">
     <name>Cordova Notification Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
Since https://github.com/apache/cordova-plugin-dialogs/pull/138 was merged and it's breaking, bumping the version to 3.0.0-dev so we don't forget