### PR TITLE
feature (GH-128) ios/android: enable programmatic dismissal of open dialogs. Resolves #128.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Although the object is attached to the global scoped `navigator`, it is not avai
 - `navigator.notification.confirm`
 - `navigator.notification.prompt`
 - `navigator.notification.beep`
+- `navigator.notification.dismissPrevious`
+- `navigator.notification.dismissAll`
 
 ## navigator.notification.alert
 
@@ -223,3 +225,63 @@ The device plays a beep sound.
 ### Android Quirks
 
 - Android plays the default __Notification ringtone__ specified under the __Settings/Sound & Display__ panel.
+
+## navigator.notification.dismissPrevious
+
+Dismisses the previously opened dialog box.
+If no dialog box is currently open, the `errorCallback` will be called.
+
+    navigator.notification.dismissPrevious([successCallback], [errorCallback])
+
+- __successCallback__: Callback to invoke when previously opened dialog has been dismissed. _(Function)_ (Optional)
+- __errorCallback__: Callback to invoke on failure to dismiss previously opened dialog. Will be passed the error message. _(Function)_ (Optional)
+
+### Example
+
+    function successCallback() {
+        console.log("Successfully dismissed previously opened dialog.");
+    }
+    
+    function errorCallback(error) {
+        console.log("Failed to dismiss previously opened dialog: " + error);
+    }
+
+    navigator.notification.dismissPrevious(
+        successCallback,
+        errorCallback
+    );
+
+### Supported Platforms
+
+- Android
+- iOS
+
+## navigator.notification.dismissAll
+
+Dismisses all previously opened dialog boxes.
+If no dialog box is currently open, the `errorCallback` will be called.
+
+    navigator.notification.dismissAll([successCallback], [errorCallback])
+
+- __successCallback__: Callback to invoke when all previously opened dialogs have been dismissed. _(Function)_ (Optional)
+- __errorCallback__: Callback to invoke on failure to dismiss all previously opened dialogs. Will be passed the error message. _(Function)_ (Optional)
+
+### Example
+
+    function successCallback() {
+        console.log("Successfully dismissed all previously opened dialogs.");
+    }
+    
+    function errorCallback(error) {
+        console.log("Failed to dismiss all previously opened dialogs: " + error);
+    }
+
+    navigator.notification.dismissAll(
+        successCallback,
+        errorCallback
+    );
+
+### Supported Platforms
+
+- Android
+- iOS

--- a/src/ios/CDVNotification.h
+++ b/src/ios/CDVNotification.h
@@ -28,5 +28,7 @@
 - (void)confirm:(CDVInvokedUrlCommand*)command;
 - (void)prompt:(CDVInvokedUrlCommand*)command;
 - (void)beep:(CDVInvokedUrlCommand*)command;
+- (void)dismissPrevious:(CDVInvokedUrlCommand*)command;
+- (void)dismissAll:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/windows/NotificationProxy.js
+++ b/src/windows/NotificationProxy.js
@@ -261,6 +261,14 @@ module.exports = {
         };
         snd.addEventListener('ended', onEvent);
         onEvent();
+    },
+
+    dismissPrevious: function () {
+        console.warn('dismissPrevious() is not available on browser platform');
+    },
+
+    dismissAll: function () {
+        console.warn('dismissAll() is not available on browser platform');
     }
 };
 

--- a/www/browser/notification.js
+++ b/www/browser/notification.js
@@ -110,3 +110,11 @@ module.exports.beep = window.navigator.notification.beep = function (times) {
         }
     }
 };
+
+module.exports.dismissPrevious = window.navigator.notification.dismissPrevious = function () {
+    console.warn('dismissPrevious() is not available on browser platform');
+};
+
+module.exports.dismissAll = window.navigator.notification.dismissAll = function () {
+    console.warn('dismissAll() is not available on browser platform');
+};

--- a/www/notification.js
+++ b/www/notification.js
@@ -107,6 +107,26 @@ module.exports = {
     beep: function (count) {
         var defaultedCount = count || 1;
         exec(null, null, 'Notification', 'beep', [defaultedCount]);
+    },
+
+    /**
+     * Close previously opened dialog
+     *
+     * @param {Function} successCallback   The callback that is called when previously opened dialog has been dismissed.
+     * @param {Function} errorCallback   The callback that is called on failure to dismiss previously opened dialog.
+     */
+    dismissPrevious: function (successCallback, errorCallback) {
+        exec(successCallback, errorCallback, 'Notification', 'dismissPrevious', []);
+    },
+
+    /**
+     * Close any open dialog.
+     *
+     * @param {Function} successCallback   The callback that is called when all previously opened dialogs have been dismissed.
+     * @param {Function} errorCallback   The callback that is called on failure to dismiss all previously opened dialogs.
+     */
+    dismissAll: function (successCallback, errorCallback) {
+        exec(successCallback, errorCallback, 'Notification', 'dismissAll', []);
     }
 };
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS and Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Enables programmatic dismissal of currently open dialogs.
Example use case is where a dialog is opened but the context for the dialog changes in real-time so the dialog is no longer relevant.

<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #128 and supersedes #79.



### Description
<!-- Describe your changes in detail -->
Two new plugin API methods have been added:
- [`dismissPrevious()`](https://github.com/dpa99c/cordova-plugin-dialogs/tree/GH-128#navigatornotificationdismissprevious) - dismisses the dialog that was most recently opened
- [`dismissAll()`](https://github.com/dpa99c/cordova-plugin-dialogs/tree/GH-128#navigatornotificationdismissall) - dismisses all open dialogs

Both functions take `successCallback` and `errorCallback` arguments:
- `successCallback` is invoked when one or more previously opened dialogs has been dismissed
- `errorCallback` is invoked if no previously opened dialogs exist to dismiss

### Testing
<!-- Please describe in detail how you tested your changes. -->
- A test harness Cordova project has been created - build+run iOS/Android platform to test new API methods: https://github.com/dpa99c/cordova-plugin-dialogs-test
- Automated tests [have been updated](https://github.com/dpa99c/cordova-plugin-dialogs/blob/GH-128/tests/tests.js#L50) to test the for existence of new API methods
- Manual tests [have been updated](https://github.com/dpa99c/cordova-plugin-dialogs/blob/GH-128/tests/tests.js#L340) to test both new API methods


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
