### PR TITLE
CDVNotification.m: Fix pointer casting in sound completion callback

### DIFF
--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -127,12 +127,12 @@ static void playBeep(int count) {
     #else
         AudioServicesCreateSystemSoundID((CFURLRef)audioPath, &completeSound);
     #endif
-    AudioServicesAddSystemSoundCompletion(completeSound, NULL, NULL, soundCompletionCallback, (void*)(cbDataCount-1));
+    AudioServicesAddSystemSoundCompletion(completeSound, NULL, NULL, soundCompletionCallback, (void *)(intptr_t)(cbDataCount - 1));
     AudioServicesPlaySystemSound(completeSound);
 }
 
 static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
-    int count = (int)data;
+    int count = (int)(intptr_t)data;
     AudioServicesRemoveSystemSoundCompletion (ssid);
     AudioServicesDisposeSystemSoundID(ssid);
     if (count > 0) {


### PR DESCRIPTION
- Corrects casting of callback data to ensure proper handling of integer values when passing and retrieving the beep count in AudioServicesAddSystemSoundCompletion and soundCompletionCallback.
- Produced the warning: `Cast to smaller integer type 'int' from 'void *'`

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
