### PR TITLE
iOS: Update top view controller retrieval for iOS multi-window

### DIFF
--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -149,14 +149,26 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
 }
 
 -(UIViewController *)getTopPresentedViewController {
+    UIWindow *keyWindow = nil;
+
+    // Get the first active window scene
+    for (UIWindowScene *windowScene in [UIApplication sharedApplication].connectedScenes) {
+        if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+            keyWindow = windowScene.windows.firstObject;
+            break;
+        }
+    }
+    
     UIViewController *presentingViewController = self.viewController;
-    if (presentingViewController.view.window != [UIApplication sharedApplication].keyWindow){
-        presentingViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+
+    if (presentingViewController.view.window != keyWindow) {
+        presentingViewController = keyWindow.rootViewController;
     }
 
     while (presentingViewController.presentedViewController != nil && ![presentingViewController.presentedViewController isBeingDismissed]){
         presentingViewController = presentingViewController.presentedViewController;
     }
+    
     return presentingViewController;
 }
 

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -151,12 +151,25 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
 -(UIViewController *)getTopPresentedViewController {
     UIWindow *keyWindow = nil;
 
-    // Get the first active window scene
-    for (UIWindowScene *windowScene in [UIApplication sharedApplication].connectedScenes) {
-        if (windowScene.activationState == UISceneActivationStateForegroundActive) {
-            keyWindow = windowScene.windows.firstObject;
-            break;
+    if (@available(iOS 13.0, *)) {
+        // iOS 13+ approach - get the first active window scene
+        // Since iOS 13, Apple introduced UIScene and multiple window support.
+        // The deprecated keyWindow property doesn't work reliably with multiple scenes
+        // as it returns a key window across all connected scenes, which can be from
+        // different app instances or windows. We need to find the active foreground
+        // scene to get the correct window for presenting our alert.
+        for (UIWindowScene *windowScene in [UIApplication sharedApplication].connectedScenes) {
+            if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+                keyWindow = windowScene.windows.firstObject;
+                break;
+            }
         }
+    } else {
+        // Fallback for iOS 11-12
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        keyWindow = [UIApplication sharedApplication].keyWindow;
+        #pragma clang diagnostic pop
     }
     
     UIViewController *presentingViewController = self.viewController;

--- a/src/ios/CDVNotification.m
+++ b/src/ios/CDVNotification.m
@@ -165,7 +165,7 @@ static void soundCompletionCallback(SystemSoundID  ssid, void* data) {
             }
         }
     } else {
-        // Fallback for iOS 11-12
+        // Fallback for older iOS versions
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         keyWindow = [UIApplication sharedApplication].keyWindow;


### PR DESCRIPTION
- Refactored getTopPresentedViewController to use the active UIWindowScene for keyWindow selection, improving compatibility with iOS multi-window environments.
- Using `[UIApplication sharedApplication].keyWindow` is deprecated since iOS 13
- Produced the deprecation warning: `'keyWindow' is deprecated: first deprecated in iOS 13.0 - Should not be used for applications that support multiple scenes as it returns a key window across all connected scenes
`
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
