### PR TITLE
fix(ios): set engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "engines": {
     "cordovaDependencies": {
       "3.0.0": {
-        "cordova-ios": ">=4.0.0"
+        "cordova-ios": ">=4.4.0"
       },
       "4.0.0": {
         "cordova": ">100"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "engines": {
     "cordovaDependencies": {
       "3.0.0": {
+        "cordova-ios": ">=4.0.0"
+      },
+      "4.0.0": {
         "cordova": ">100"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,6 +29,10 @@
     <repo>https://github.com/apache/cordova-plugin-dialogs</repo>
     <issue>https://github.com/apache/cordova-plugin-dialogs/issues</issue>
 
+    <engines>
+            <engine name="cordova-ios" version=">=4.0.0" />
+    </engines>
+
     <js-module src="www/notification.js" name="notification">
         <merges target="navigator.notification" />
     </js-module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
     <issue>https://github.com/apache/cordova-plugin-dialogs/issues</issue>
 
     <engines>
-            <engine name="cordova-ios" version=">=4.0.0" />
+            <engine name="cordova-ios" version=">=4.4.0" />
     </engines>
 
     <js-module src="www/notification.js" name="notification">


### PR DESCRIPTION
In https://github.com/apache/cordova-plugin-dialogs/pull/138 I removed code for iOS < 8.3, so I'm setting the engine to at least cordova-ios 4.4.0 as it was when the deployment target was set to iOS 9 (yes, it was done in a minor).
While the code works on iOS 8+. there was a bug on 8.0 to 8.2 and I've removed the workaround, so better require iOS 9+.
I could set it to even a higher cordova-ios version if desired since those versions are ancient anyway.

Also moved the >100 to a 4.0.0 version so the 3.0.0 version of the plugin can be installed